### PR TITLE
Removed Robot Framework upper version limit to allow 7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "robotframework-gevent"
-version = "0.7.0"
+version = "0.7.1"
 description = "Run keywords asynchronously with the power of gevent"
 authors = ["Eldad Uzman <eldadu1985@gmail.com>"]
 license = "MIT"
@@ -15,7 +15,7 @@ keywords = ["robotframework", "rpa", "automation", "asynchronous"]
 [tool.poetry.dependencies]
 python = "^3.8"
 gevent = ">=21.12,<24.0"
-robotframework = ">=5.0.1,<7.0.0"
+robotframework = ">=5.0.1"
 robotframework-pythonlibcore = ">=3,<5"
 aiohttp = "^3.9.1"
 


### PR DESCRIPTION
Seems to be artificial limitation.
I have ran atests with Python 3.12 and Robot Framework 7.0.